### PR TITLE
Feature/add pagination

### DIFF
--- a/entities/post.go
+++ b/entities/post.go
@@ -28,4 +28,6 @@ type UpdateText struct {
 type FilterRequest struct {
 	Tags      []string `json:"tags"`
 	Usernames []string `json:"usernames"`
+	Limit     int      `json:"limit"`
+	LastID    string   `json:"lastid"`
 }


### PR DESCRIPTION
- Extract limit or set page default to 10. 
- Retrieve documents greater than lastObjectID (next page). 
- Add limit to query and sort by id for stable ordering. 
- Determine ID of last document on page, and send that in response for next cursor
- Added LastID and Limit to FilterRequest struct